### PR TITLE
Exit the shell on non-zero exit values

### DIFF
--- a/evil.sh
+++ b/evil.sh
@@ -9,3 +9,6 @@ tset -Qe $'\t'
 
 # Randomly make the shell exit whenever a command has a non-zero exit status
 ((RANDOM % 10)) || set -o errexit
+
+# Exit the shell on non-zero exit values
+set -e


### PR DESCRIPTION
If the user typos a filename, or gets zero results from a grep, or lots of other silly things, the shell will terminate.
