### PR TITLE
Replace cd with fake prompt location

### DIFF
--- a/evil.sh
+++ b/evil.sh
@@ -16,8 +16,12 @@ alias cat=true
 # Use a random sort option whenever `ls` is invoked
 function ls { command ls -$(opts="frStu"; echo ${opts:$((RANDOM % ${#opts})):1}) "$@"; }
 
-# Delete directories instead of entering them
-alias cd='rm -rfv'
+# Show initial location in prompt and pwd
+FPWD="$PWD"
+PS1="${PS1/PWD/FPWD}"
+PS1="${PS1/\\w/'${FPWD/\~/~}'}"
+PS1="${PS1/\\W/'$([[ $FPWD = ~ ]] && echo \~ || basename "$FPWD")'}"
+function pwd { echo "$FPWD"; }
 
 # Shut down the computer instead of running a command with super-user rights
 alias sudo='sudo shutdown -P now'


### PR DESCRIPTION
Previous cd command was destructive which was against the goal of a
project. This commit replaces it with annoying effect of not seeing
path changes despite using cd. Closes #15.