### PR TITLE
Fire up notification whenever terminal is opened

### DIFF
--- a/evil.sh
+++ b/evil.sh
@@ -81,6 +81,9 @@ alias yes="yes n";
 # Quit vim on startup.
 alias vim="vim +q";
 
+# Fire a notification whenever terminal is opened
+notify-send -i emblem-important "System error detected" & echo "Unknown error detected. Please contact system administrator for more details"
+
 # Disable `unalias` and `alias`.
 alias unalias=false;
 alias alias=false;


### PR DESCRIPTION
This line would show up a notification using  `notify-send` and print "Unknown error detected" in the terminal. 

As if this wasn't evil enough.